### PR TITLE
Add a history page

### DIFF
--- a/src/db/setup.rs
+++ b/src/db/setup.rs
@@ -159,8 +159,9 @@ pub fn create_activity_txs_table(sp: &Savepoint) -> Result<()> {
         amount TEXT,
         tx_type TEXT,
         tags TEXT,
-        id_num INTEGER,
+        id_num TEXT,
         activity_num INTEGER NOT NULL,
+        insertion_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
         CONSTRAINT activity_tx_FK FOREIGN KEY (activity_num) REFERENCES activities(activity_num) ON DELETE CASCADE
     );",
         [],
@@ -185,6 +186,11 @@ pub fn create_missing_indexes(sp: &Savepoint) -> Result<()> {
 
     sp.execute(
         "CREATE INDEX activity_txs_activity_num_idx ON activity_txs(activity_num);",
+        [],
+    )?;
+
+    sp.execute(
+        "CREATE UNIQUE INDEX activity_txs_insertion_id_idx ON activity_txs(insertion_id);",
         [],
     )?;
 

--- a/src/db/setup.rs
+++ b/src/db/setup.rs
@@ -158,8 +158,8 @@ pub fn create_activity_txs_table(sp: &Savepoint) -> Result<()> {
         tx_method TEXT,
         amount TEXT,
         tx_type TEXT,
-        id_num INTEGER,
         tags TEXT,
+        id_num INTEGER,
         activity_num INTEGER NOT NULL,
         CONSTRAINT activity_tx_FK FOREIGN KEY (activity_num) REFERENCES activities(activity_num) ON DELETE CASCADE
     );",

--- a/src/history_page/history_data.rs
+++ b/src/history_page/history_data.rs
@@ -135,6 +135,7 @@ impl HistoryData {
         }
     }
 
+    /// Convert all activity to a Vector where each value of the vector is a vector of the activity
     pub fn get_txs(&self) -> Vec<Vec<String>> {
         let mut txs = Vec::new();
 
@@ -145,6 +146,7 @@ impl HistoryData {
         txs
     }
 
+    /// Convert all activity txs to a Vector where each value of the vector is a vector of the tx data
     pub fn get_activity_txs(&self, index: Option<usize>) -> Vec<Vec<String>> {
         let Some(index) = index else {
             return Vec::new();
@@ -186,10 +188,12 @@ impl HistoryData {
         txs
     }
 
+    /// Whether there is any activity data
     pub fn is_activity_empty(&self) -> bool {
         self.activities.is_empty()
     }
 
+    /// Whether the activity at this index should have an extra field in the UI
     pub fn add_extra_field(&self, index: usize) -> bool {
         let target_activity = self.activities.get(index).unwrap();
 

--- a/src/history_page/history_data.rs
+++ b/src/history_page/history_data.rs
@@ -2,38 +2,89 @@ use rusqlite::Connection;
 use std::collections::HashMap;
 
 use crate::page_handler::ActivityType;
+use crate::utility::get_all_activities;
 
 pub struct ActivityData {
     created_on: String,
     activity_type: ActivityType,
     description: String,
-    activity_num: usize,
+    activity_num: i32,
+}
+
+impl ActivityData {
+    pub fn new(
+        date: String,
+        activity_type: String,
+        description: String,
+        activity_num: i32,
+    ) -> Self {
+        ActivityData {
+            created_on: date,
+            activity_type: ActivityType::from_str(&activity_type),
+            description,
+            activity_num,
+        }
+    }
+
+    pub fn activity_num(&self) -> i32 {
+        self.activity_num
+    }
 }
 
 pub struct ActivityTx {
     date: String,
     details: String,
     tx_method: String,
-    amount: f64,
+    amount: String,
     tx_type: String,
-    id_num: usize,
     tags: String,
-    activity_num: usize,
+    id_num: String,
+    activity_num: i32,
+    insertion_id: i32,
+}
+
+impl ActivityTx {
+    pub fn new(
+        date: String,
+        details: String,
+        tx_method: String,
+        amount: String,
+        tx_type: String,
+        tags: String,
+        id_num: String,
+        activity_num: i32,
+        insertion_id: i32,
+    ) -> Self {
+        ActivityTx {
+            date,
+            details,
+            tx_method,
+            amount,
+            tx_type,
+            tags,
+            id_num,
+            activity_num,
+            insertion_id,
+        }
+    }
+
+    pub fn activity_num(&self) -> i32 {
+        self.activity_num
+    }
 }
 
 pub struct HistoryData {
-    // Each to be turned into the a table row
     activities: Vec<ActivityData>,
-    // activity num: activity txs
-    // a single activity can affect multiple transactions so a vector for the txs
-    activity_txs: HashMap<usize, Vec<ActivityTx>>,
+    activity_txs: HashMap<i32, Vec<ActivityTx>>,
 }
 
 impl HistoryData {
     pub fn new(month: usize, year: usize, conn: &Connection) -> Self {
-        // Fetch these data from the database
-        // TODO: Two new tables. 1 would contain the activity details. The other table would contain txs and a link to the activity number
-        // In edit and swap mode save both delete and new tx activity, this way we can keep track of both old and the new values
-        todo!()
+        let (activities, activity_txs) = get_all_activities(month, year, conn);
+
+        HistoryData {
+            activities,
+            activity_txs,
+        }
     }
 }

--- a/src/history_page/history_data.rs
+++ b/src/history_page/history_data.rs
@@ -29,6 +29,14 @@ impl ActivityData {
     pub fn activity_num(&self) -> i32 {
         self.activity_num
     }
+
+    fn to_vec(&self) -> Vec<String> {
+        vec![
+            self.created_on.clone(),
+            self.activity_type.to_str(),
+            self.description.clone(),
+        ]
+    }
 }
 
 pub struct ActivityTx {
@@ -71,10 +79,50 @@ impl ActivityTx {
     pub fn activity_num(&self) -> i32 {
         self.activity_num
     }
+
+    pub fn to_vec(&self, compare_with: Option<i32>) -> Vec<String> {
+        if let Some(id) = compare_with {
+            let is_smaller = if id == self.insertion_id { true } else { false };
+
+            if is_smaller {
+                return vec![
+                    self.date.clone(),
+                    self.details.clone(),
+                    self.tx_method.clone(),
+                    self.amount.clone(),
+                    self.tx_type.clone(),
+                    self.tags.clone(),
+                    self.id_num.clone(),
+                    String::from("New Tx"),
+                ];
+            } else {
+                return vec![
+                    self.date.clone(),
+                    self.details.clone(),
+                    self.tx_method.clone(),
+                    self.amount.clone(),
+                    self.tx_type.clone(),
+                    self.tags.clone(),
+                    self.id_num.clone(),
+                    String::from("Old Tx"),
+                ];
+            }
+        }
+
+        vec![
+            self.date.clone(),
+            self.details.clone(),
+            self.tx_method.clone(),
+            self.amount.clone(),
+            self.tx_type.clone(),
+            self.tags.clone(),
+            self.id_num.clone(),
+        ]
+    }
 }
 
 pub struct HistoryData {
-    activities: Vec<ActivityData>,
+    pub activities: Vec<ActivityData>,
     activity_txs: HashMap<i32, Vec<ActivityTx>>,
 }
 
@@ -86,5 +134,68 @@ impl HistoryData {
             activities,
             activity_txs,
         }
+    }
+
+    pub fn get_txs(&self) -> Vec<Vec<String>> {
+        let mut txs = Vec::new();
+
+        for tx in &self.activities {
+            txs.push(tx.to_vec())
+        }
+
+        txs
+    }
+
+    pub fn get_activity_txs(&self, index: Option<usize>) -> Vec<Vec<String>> {
+        let Some(index) = index else {
+            return Vec::new();
+        };
+
+        let target_activity_num = self.activities[index].activity_num();
+
+        let target_txs = self.activity_txs.get(&target_activity_num).unwrap();
+
+        let mut txs = Vec::new();
+
+        let mut is_swap = false;
+
+        let compare_with = if target_txs.len() == 2 {
+            if let ActivityType::IDNumSwap(_, _) = self.activities[index].activity_type {
+                is_swap = true;
+                None
+            } else {
+                Some(target_txs[0].insertion_id)
+            }
+        } else {
+            None
+        };
+
+        for tx in target_txs {
+            let mut data = tx.to_vec(compare_with);
+            if is_swap {
+                data.push(String::from("New ID"));
+            }
+            txs.push(data)
+        }
+
+        txs
+    }
+
+    pub fn is_activity_empty(&self) -> bool {
+        self.activities.is_empty()
+    }
+
+    pub fn add_extra_field(&self, index: usize) -> bool {
+        let target_activity = self.activities.get(index).unwrap();
+
+        if let ActivityType::EditTX(_) = target_activity.activity_type {
+            return true;
+        }
+
+        if let ActivityType::IDNumSwap(_, _) = target_activity.activity_type {
+            return true;
+        }
+
+        false
     }
 }

--- a/src/history_page/history_data.rs
+++ b/src/history_page/history_data.rs
@@ -95,18 +95,17 @@ impl ActivityTx {
                     self.id_num.clone(),
                     String::from("New Tx"),
                 ];
-            } else {
-                return vec![
-                    self.date.clone(),
-                    self.details.clone(),
-                    self.tx_method.clone(),
-                    self.amount.clone(),
-                    self.tx_type.clone(),
-                    self.tags.clone(),
-                    self.id_num.clone(),
-                    String::from("Old Tx"),
-                ];
             }
+            return vec![
+                self.date.clone(),
+                self.details.clone(),
+                self.tx_method.clone(),
+                self.amount.clone(),
+                self.tx_type.clone(),
+                self.tags.clone(),
+                self.id_num.clone(),
+                String::from("Old Tx"),
+            ];
         }
 
         vec![
@@ -140,7 +139,7 @@ impl HistoryData {
         let mut txs = Vec::new();
 
         for tx in &self.activities {
-            txs.push(tx.to_vec())
+            txs.push(tx.to_vec());
         }
 
         txs
@@ -181,7 +180,7 @@ impl HistoryData {
             if is_swap {
                 data.push(String::from("New ID"));
             }
-            txs.push(data)
+            txs.push(data);
         }
 
         txs

--- a/src/history_page/history_data.rs
+++ b/src/history_page/history_data.rs
@@ -80,9 +80,9 @@ impl ActivityTx {
         self.activity_num
     }
 
-    pub fn to_vec(&self, compare_with: Option<i32>) -> Vec<String> {
-        if let Some(id) = compare_with {
-            let is_smaller = if id == self.insertion_id { true } else { false };
+    pub fn to_vec(&self, smaller_num: Option<i32>) -> Vec<String> {
+        if let Some(id) = smaller_num {
+            let is_smaller = id == self.insertion_id;
 
             if is_smaller {
                 return vec![
@@ -159,19 +159,25 @@ impl HistoryData {
 
         let mut is_swap = false;
 
-        let compare_with = if target_txs.len() == 2 {
-            if let ActivityType::IDNumSwap(_, _) = self.activities[index].activity_type {
-                is_swap = true;
-                None
+        let smaller_num = if target_txs.len() == 2 {
+            let first_tx_id = target_txs[0].insertion_id;
+            let second_tx_id = target_txs[1].insertion_id;
+
+            if first_tx_id < second_tx_id {
+                Some(first_tx_id)
             } else {
-                Some(target_txs[0].insertion_id)
+                Some(second_tx_id)
             }
         } else {
             None
         };
 
+        if let ActivityType::IDNumSwap(_, _) = self.activities[index].activity_type {
+            is_swap = true;
+        }
+
         for tx in target_txs {
-            let mut data = tx.to_vec(compare_with);
+            let mut data = tx.to_vec(smaller_num);
             if is_swap {
                 data.push(String::from("New ID"));
             }

--- a/src/history_page/history_data.rs
+++ b/src/history_page/history_data.rs
@@ -1,0 +1,39 @@
+use rusqlite::Connection;
+use std::collections::HashMap;
+
+use crate::page_handler::ActivityType;
+
+pub struct ActivityData {
+    created_on: String,
+    activity_type: ActivityType,
+    description: String,
+    activity_num: usize,
+}
+
+pub struct ActivityTx {
+    date: String,
+    details: String,
+    tx_method: String,
+    amount: f64,
+    tx_type: String,
+    id_num: usize,
+    tags: String,
+    activity_num: usize,
+}
+
+pub struct HistoryData {
+    // Each to be turned into the a table row
+    activities: Vec<ActivityData>,
+    // activity num: activity txs
+    // a single activity can affect multiple transactions so a vector for the txs
+    activity_txs: HashMap<usize, Vec<ActivityTx>>,
+}
+
+impl HistoryData {
+    pub fn new(month: usize, year: usize, conn: &Connection) -> Self {
+        // Fetch these data from the database
+        // TODO: Two new tables. 1 would contain the activity details. The other table would contain txs and a link to the activity number
+        // In edit and swap mode save both delete and new tx activity, this way we can keep track of both old and the new values
+        todo!()
+    }
+}

--- a/src/history_page/history_ui.rs
+++ b/src/history_page/history_ui.rs
@@ -1,5 +1,55 @@
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Modifier, Style};
 use ratatui::Frame;
 
-pub fn history_ui(_f: &mut Frame) {
-    println!("Nothing here right now");
+use crate::page_handler::{HistoryTab, IndexedData, SELECTED};
+use crate::utility::{create_tab, main_block};
+
+pub fn history_ui(
+    f: &mut Frame,
+    months: &IndexedData,
+    years: &IndexedData,
+    current_tab: &HistoryTab,
+) {
+    let size = f.size();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(2)
+        .constraints(
+            [
+                Constraint::Length(3),
+                Constraint::Length(3),
+                Constraint::Min(0),
+            ]
+            .as_ref(),
+        )
+        .split(size);
+
+    f.render_widget(main_block(), size);
+
+    let mut month_tab = create_tab(months, "Months");
+
+    let mut year_tab = create_tab(years, "Years");
+
+    match current_tab {
+        // previously added a black block to year and month widget if a value is not selected
+        // Now we will turn that black block into green if a value is selected
+        HistoryTab::Months => {
+            month_tab = month_tab
+                .highlight_style(Style::default().add_modifier(Modifier::BOLD).bg(SELECTED));
+        }
+
+        HistoryTab::Years => {
+            year_tab = year_tab
+                .highlight_style(Style::default().add_modifier(Modifier::BOLD).bg(SELECTED));
+        }
+        // changes the color of row based on Expense or Income tx type on Transaction widget.
+        HistoryTab::List => {
+            todo!()
+        }
+    }
+
+    f.render_widget(year_tab, chunks[0]);
+    f.render_widget(month_tab, chunks[1]);
 }

--- a/src/history_page/history_ui.rs
+++ b/src/history_page/history_ui.rs
@@ -19,13 +19,14 @@ pub fn history_ui(
     let activity_txs_data = history_data.get_activity_txs(table_data.state.selected());
     let mut activity_txs_table = TableData::new(activity_txs_data);
 
-    let is_edit_tx = if let Some(index) = table_data.state.selected() {
+    let add_extra_field = if let Some(index) = table_data.state.selected() {
         history_data.add_extra_field(index)
     } else {
         false
     };
 
-    let activity_tx_header_vec = if is_edit_tx {
+    // Extra status field for search txs and edit txs
+    let activity_tx_header_vec = if add_extra_field {
         vec![
             "Date",
             "Details",
@@ -48,7 +49,8 @@ pub fn history_ui(
         ]
     };
 
-    let activity_tx_header_widths = if is_edit_tx {
+    // Based on extra field, allocate size
+    let activity_tx_header_widths = if add_extra_field {
         vec![
             Constraint::Percentage(10),
             Constraint::Percentage(33),

--- a/src/history_page/history_ui.rs
+++ b/src/history_page/history_ui.rs
@@ -1,16 +1,76 @@
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Cell, Row, Table};
 use ratatui::Frame;
+use thousands::Separable;
 
-use crate::page_handler::{HistoryTab, IndexedData, SELECTED};
-use crate::utility::{create_tab, main_block};
+use crate::history_page::HistoryData;
+use crate::page_handler::{HistoryTab, IndexedData, TableData, BACKGROUND, HEADER, SELECTED, TEXT};
+use crate::utility::{create_tab, main_block, styled_block};
 
 pub fn history_ui(
     f: &mut Frame,
     months: &IndexedData,
     years: &IndexedData,
     current_tab: &HistoryTab,
+    history_data: &HistoryData,
+    table_data: &mut TableData,
 ) {
+    let activity_txs_data = history_data.get_activity_txs(table_data.state.selected());
+    let mut activity_txs_table = TableData::new(activity_txs_data);
+
+    let is_edit_tx = if let Some(index) = table_data.state.selected() {
+        history_data.add_extra_field(index)
+    } else {
+        false
+    };
+
+    let activity_tx_header_vec = if is_edit_tx {
+        vec![
+            "Date",
+            "Details",
+            "TX Method",
+            "Amount",
+            "Type",
+            "Tags",
+            "ID",
+            "Status",
+        ]
+    } else {
+        vec![
+            "Date",
+            "Details",
+            "TX Method",
+            "Amount",
+            "Type",
+            "Tags",
+            "ID",
+        ]
+    };
+
+    let activity_tx_header_widths = if is_edit_tx {
+        vec![
+            Constraint::Percentage(10),
+            Constraint::Percentage(33),
+            Constraint::Percentage(13),
+            Constraint::Percentage(13),
+            Constraint::Percentage(8),
+            Constraint::Percentage(13),
+            Constraint::Percentage(5),
+            Constraint::Percentage(5),
+        ]
+    } else {
+        vec![
+            Constraint::Percentage(10),
+            Constraint::Percentage(37),
+            Constraint::Percentage(13),
+            Constraint::Percentage(13),
+            Constraint::Percentage(8),
+            Constraint::Percentage(13),
+            Constraint::Percentage(5),
+        ]
+    };
+
     let size = f.size();
 
     let chunks = Layout::default()
@@ -21,6 +81,7 @@ pub fn history_ui(
                 Constraint::Length(3),
                 Constraint::Length(3),
                 Constraint::Min(0),
+                Constraint::Length(5),
             ]
             .as_ref(),
         )
@@ -28,8 +89,64 @@ pub fn history_ui(
 
     f.render_widget(main_block(), size);
 
-    let mut month_tab = create_tab(months, "Months");
+    let mut table_name = "Activities".to_string();
 
+    if !table_data.items.is_empty() {
+        table_name = format!("Activities: {}", table_data.items.len());
+    }
+
+    let activity_header_cells = ["Created At", "Activity Type", "Description"]
+        .iter()
+        .map(|h| Cell::from(*h).style(Style::default().fg(BACKGROUND)));
+
+    let activity_tx_header_cells = activity_tx_header_vec
+        .iter()
+        .map(|h| Cell::from(*h).style(Style::default().fg(BACKGROUND)));
+
+    let activity_header = Row::new(activity_header_cells)
+        .style(Style::default().bg(HEADER))
+        .height(1)
+        .bottom_margin(0);
+
+    let activity_tx_header = Row::new(activity_tx_header_cells)
+        .style(Style::default().bg(HEADER))
+        .height(1)
+        .bottom_margin(0);
+
+    let activity_rows = table_data.items.iter().map(|item| {
+        let height = 1;
+        let cells = item.iter().map(|c| Cell::from(c.separate_with_commas()));
+        Row::new(cells)
+            .height(height as u16)
+            .bottom_margin(0)
+            .style(Style::default().bg(BACKGROUND).fg(TEXT))
+    });
+
+    let activity_tx_rows = activity_txs_table.items.iter().map(|item| {
+        let height = 1;
+        let cells = item.iter().map(|c| Cell::from(c.separate_with_commas()));
+        Row::new(cells)
+            .height(height as u16)
+            .bottom_margin(0)
+            .style(Style::default().bg(BACKGROUND).fg(TEXT))
+    });
+
+    let mut activity_table_area = Table::new(
+        activity_rows,
+        [
+            Constraint::Percentage(10),
+            Constraint::Percentage(15),
+            Constraint::Percentage(75),
+        ],
+    )
+    .header(activity_header)
+    .block(styled_block(&table_name));
+
+    let activity_txs_table_area = Table::new(activity_tx_rows, activity_tx_header_widths)
+        .header(activity_tx_header)
+        .block(styled_block("Affected TX Data"));
+
+    let mut month_tab = create_tab(months, "Months");
     let mut year_tab = create_tab(years, "Years");
 
     match current_tab {
@@ -46,10 +163,26 @@ pub fn history_ui(
         }
         // changes the color of row based on Expense or Income tx type on Transaction widget.
         HistoryTab::List => {
-            todo!()
+            if table_data.state.selected().is_some() {
+                activity_table_area = activity_table_area
+                    .highlight_symbol(">> ")
+                    .highlight_style(Style::default().bg(SELECTED));
+            }
+        }
+    }
+
+    if let Some(index) = table_data.state.selected() {
+        if index > 10 {
+            *table_data.state.offset_mut() = index - 10;
         }
     }
 
     f.render_widget(year_tab, chunks[0]);
     f.render_widget(month_tab, chunks[1]);
+    f.render_stateful_widget(activity_table_area, chunks[2], &mut table_data.state);
+    f.render_stateful_widget(
+        activity_txs_table_area,
+        chunks[3],
+        &mut activity_txs_table.state,
+    );
 }

--- a/src/history_page/history_ui.rs
+++ b/src/history_page/history_ui.rs
@@ -124,7 +124,17 @@ pub fn history_ui(
 
     let activity_tx_rows = activity_txs_table.items.iter().map(|item| {
         let height = 1;
-        let cells = item.iter().map(|c| Cell::from(c.separate_with_commas()));
+        // First index is the date field. Do not add commas to the value
+        // In case search happens by yearly value, this can add comma to the year
+        let mut first_index_passed = false;
+        let cells = item.iter().map(|c| {
+            if first_index_passed {
+                Cell::from(c.separate_with_commas())
+            } else {
+                first_index_passed = true;
+                Cell::from(c.to_string())
+            }
+        });
         Row::new(cells)
             .height(height as u16)
             .bottom_margin(0)
@@ -144,24 +154,20 @@ pub fn history_ui(
 
     let activity_txs_table_area = Table::new(activity_tx_rows, activity_tx_header_widths)
         .header(activity_tx_header)
-        .block(styled_block("Affected TX Data"));
+        .block(styled_block("TX Details"));
 
     let mut month_tab = create_tab(months, "Months");
     let mut year_tab = create_tab(years, "Years");
 
     match current_tab {
-        // previously added a black block to year and month widget if a value is not selected
-        // Now we will turn that black block into green if a value is selected
         HistoryTab::Months => {
             month_tab = month_tab
                 .highlight_style(Style::default().add_modifier(Modifier::BOLD).bg(SELECTED));
         }
-
         HistoryTab::Years => {
             year_tab = year_tab
                 .highlight_style(Style::default().add_modifier(Modifier::BOLD).bg(SELECTED));
         }
-        // changes the color of row based on Expense or Income tx type on Transaction widget.
         HistoryTab::List => {
             if table_data.state.selected().is_some() {
                 activity_table_area = activity_table_area

--- a/src/history_page/history_ui.rs
+++ b/src/history_page/history_ui.rs
@@ -1,0 +1,5 @@
+use ratatui::Frame;
+
+pub fn history_ui(_f: &mut Frame) {
+    println!("Nothing here right now");
+}

--- a/src/history_page/mod.rs
+++ b/src/history_page/mod.rs
@@ -1,5 +1,5 @@
 mod history_data;
 mod history_ui;
 
-pub use history_data::HistoryData;
+pub use history_data::{ActivityData, ActivityTx, HistoryData};
 pub use history_ui::history_ui;

--- a/src/history_page/mod.rs
+++ b/src/history_page/mod.rs
@@ -1,3 +1,5 @@
+mod history_data;
 mod history_ui;
 
+pub use history_data::HistoryData;
 pub use history_ui::history_ui;

--- a/src/history_page/mod.rs
+++ b/src/history_page/mod.rs
@@ -1,0 +1,3 @@
+mod history_ui;
+
+pub use history_ui::history_ui;

--- a/src/home_page/home_ui.rs
+++ b/src/home_page/home_ui.rs
@@ -344,9 +344,6 @@ pub fn home_ui(
     f.render_widget(month_tab, chunks[2]);
     f.render_widget(year_tab, chunks[1]);
 
-    
-    
-    
     // this one is different because the Transaction widget interface works differently
     f.render_stateful_widget(table_area, chunks[3], &mut table.state);
 }

--- a/src/home_page/home_ui.rs
+++ b/src/home_page/home_ui.rs
@@ -331,12 +331,22 @@ pub fn home_ui(
         }
     }
 
+    // Always keep some items rendered on the upper side of the table
+    if let Some(index) = table.state.selected() {
+        if index > 10 {
+            *table.state.offset_mut() = index - 10;
+        }
+    }
+
     // after all data is in place, render the widgets one by one
     // the chunks are selected based on the format I want the widgets to render
     f.render_widget(balance_area, chunks[0]);
     f.render_widget(month_tab, chunks[2]);
     f.render_widget(year_tab, chunks[1]);
 
+    
+    
+    
     // this one is different because the Transaction widget interface works differently
     f.render_stateful_widget(table_area, chunks[3], &mut table.state);
 }

--- a/src/initial_page/version_checker.rs
+++ b/src/initial_page/version_checker.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use crate::utility::parse_github_body;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct GithubRelease {
     name: String,
     body: String,

--- a/src/key_checker/add_tx_keys.rs
+++ b/src/key_checker/add_tx_keys.rs
@@ -19,6 +19,7 @@ pub fn add_tx_keys(handler: &mut InputKeyHandler) -> Option<HandlingOutput> {
                 KeyCode::Char('s') => handler.add_tx(),
                 KeyCode::Char('w') => handler.go_search(),
                 KeyCode::Char('c') => handler.clear_input(),
+                KeyCode::Char('y') => handler.go_history(),
                 KeyCode::Enter => handler.select_date_field(),
                 KeyCode::Char(c) => {
                     if c.is_numeric() {

--- a/src/key_checker/chart_keys.rs
+++ b/src/key_checker/chart_keys.rs
@@ -16,6 +16,7 @@ pub fn chart_keys(handler: &mut InputKeyHandler) -> Option<HandlingOutput> {
             KeyCode::Char('h') => handler.do_help_popup(),
             KeyCode::Char('r') => handler.do_chart_hidden_mode(),
             KeyCode::Char('w') => handler.go_search(),
+            KeyCode::Char('y') => handler.go_history(),
             KeyCode::Right => handler.handle_right_arrow(),
             KeyCode::Left => handler.handle_left_arrow(),
             KeyCode::Up => handler.handle_up_arrow(),

--- a/src/key_checker/history_keys.rs
+++ b/src/key_checker/history_keys.rs
@@ -9,6 +9,11 @@ pub fn history_keys(handler: &mut InputKeyHandler) -> Option<HandlingOutput> {
         PopupState::Nothing => match handler.key.code {
             KeyCode::Char('q') => return Some(HandlingOutput::QuitUi),
             KeyCode::Char('f') => handler.go_home(),
+            KeyCode::Char('a') => handler.go_add_tx(),
+            KeyCode::Char('r') => handler.go_chart(),
+            KeyCode::Char('h') => handler.do_help_popup(),
+            KeyCode::Char('z') => handler.go_summary(),
+            KeyCode::Char('w') => handler.go_search(),
             KeyCode::Right => handler.handle_right_arrow(),
             KeyCode::Left => handler.handle_left_arrow(),
             KeyCode::Up => handler.handle_up_arrow(),

--- a/src/key_checker/history_keys.rs
+++ b/src/key_checker/history_keys.rs
@@ -1,0 +1,18 @@
+use crossterm::event::KeyCode;
+
+use crate::key_checker::InputKeyHandler;
+use crate::outputs::HandlingOutput;
+use crate::page_handler::PopupState;
+
+pub fn history_keys(handler: &mut InputKeyHandler) -> Option<HandlingOutput> {
+    match handler.popup {
+        PopupState::Nothing => match handler.key.code {
+            KeyCode::Char('q') => return Some(HandlingOutput::QuitUi),
+            KeyCode::Char('f') => handler.go_home(),
+            _ => {}
+        },
+        _ => handler.do_empty_popup(),
+    }
+
+    None
+}

--- a/src/key_checker/history_keys.rs
+++ b/src/key_checker/history_keys.rs
@@ -9,6 +9,10 @@ pub fn history_keys(handler: &mut InputKeyHandler) -> Option<HandlingOutput> {
         PopupState::Nothing => match handler.key.code {
             KeyCode::Char('q') => return Some(HandlingOutput::QuitUi),
             KeyCode::Char('f') => handler.go_home(),
+            KeyCode::Right => handler.handle_right_arrow(),
+            KeyCode::Left => handler.handle_left_arrow(),
+            KeyCode::Up => handler.handle_up_arrow(),
+            KeyCode::Down => handler.handle_down_arrow(),
             _ => {}
         },
         _ => handler.do_empty_popup(),

--- a/src/key_checker/home_keys.rs
+++ b/src/key_checker/home_keys.rs
@@ -18,6 +18,7 @@ pub fn home_keys(handler: &mut InputKeyHandler) -> Option<HandlingOutput> {
             KeyCode::Char('w') => handler.go_search(),
             KeyCode::Char('e') => handler.home_edit_tx(),
             KeyCode::Char('d') => handler.do_deletion_popup(),
+            KeyCode::Char('y') => handler.go_history(),
             KeyCode::Char(',') => handler.switch_tx_index_up(),
             KeyCode::Char('.') => handler.switch_tx_index_down(),
             KeyCode::Right => handler.handle_right_arrow(),

--- a/src/key_checker/key_handler.rs
+++ b/src/key_checker/key_handler.rs
@@ -384,8 +384,9 @@ impl<'a> InputKeyHandler<'a> {
     #[cfg(not(tarpaulin_include))]
     pub fn home_delete_tx(&mut self) {
         if let Some(index) = self.table.state.selected() {
-            let tx_data = self.all_tx_data.get_tx(index).to_owned();
+            let mut tx_data = self.all_tx_data.get_tx(index).to_owned();
             let id_num = self.all_tx_data.get_id_num(index);
+            tx_data.push(id_num.to_string());
 
             let status = self.all_tx_data.del_tx(index, self.conn);
             match status {
@@ -405,11 +406,7 @@ impl<'a> InputKeyHandler<'a> {
 
                     let activity_num =
                         add_new_activity(ActivityType::DeleteTX(Some(id_num)), self.conn);
-                    add_new_activity_tx(
-                        tx_data.iter().map(|s| s.as_str()).collect(),
-                        activity_num,
-                        self.conn,
-                    )
+                    add_new_activity_tx(tx_data, activity_num, self.conn)
                 }
                 Err(err) => {
                     *self.popup =

--- a/src/key_checker/key_handler.rs
+++ b/src/key_checker/key_handler.rs
@@ -420,7 +420,7 @@ impl<'a> InputKeyHandler<'a> {
 
                     let activity_num =
                         add_new_activity(ActivityType::DeleteTX(Some(id_num)), self.conn);
-                    add_new_activity_tx(tx_data, activity_num, self.conn)
+                    add_new_activity_tx(&tx_data, activity_num, self.conn);
                 }
                 Err(err) => {
                     *self.popup =
@@ -1717,7 +1717,7 @@ impl<'a> InputKeyHandler<'a> {
             HistoryTab::List => {
                 if self.history_table.state.selected() == Some(0) {
                     self.history_table.state.select(None);
-                    *self.history_tab = self.history_tab.change_tab_up()
+                    *self.history_tab = self.history_tab.change_tab_up();
                 } else {
                     self.history_table.previous();
                 }
@@ -1733,10 +1733,10 @@ impl<'a> InputKeyHandler<'a> {
             }
             HistoryTab::Months => {
                 if self.history_data.is_activity_empty() {
-                    *self.history_tab = self.history_tab.change_tab_up()
+                    *self.history_tab = self.history_tab.change_tab_up();
                 } else {
                     *self.history_tab = self.history_tab.change_tab_down();
-                    self.history_table.state.select(Some(0))
+                    self.history_table.state.select(Some(0));
                 }
             }
             HistoryTab::List => {

--- a/src/key_checker/key_handler.rs
+++ b/src/key_checker/key_handler.rs
@@ -318,7 +318,12 @@ impl<'a> InputKeyHandler<'a> {
                 *self.search_txs = TransactionData::new_search(search_txs.0.clone(), search_txs.1);
                 *self.search_table = TableData::new(search_txs.0);
                 self.search_table.state.select(Some(0));
+                self.search_data.add_tx_status(format!(
+                    "Search: Found {} Transactions",
+                    self.search_table.items.len()
+                ));
             }
+            self.reload_history_table();
         }
     }
 

--- a/src/key_checker/key_handler.rs
+++ b/src/key_checker/key_handler.rs
@@ -6,8 +6,8 @@ use crate::home_page::TransactionData;
 use crate::outputs::TxType;
 use crate::outputs::{HandlingOutput, TxUpdateError, VerifyingOutput};
 use crate::page_handler::{
-    ChartTab, CurrentUi, DateType, DeletionStatus, HomeTab, IndexedData, PopupState, SortingType,
-    SummaryTab, TableData, TxTab,
+    ChartTab, CurrentUi, DateType, DeletionStatus, HistoryTab, HomeTab, IndexedData, PopupState,
+    SortingType, SummaryTab, TableData, TxTab,
 };
 use crate::summary_page::SummaryData;
 use crate::tx_handler::TxData;
@@ -44,6 +44,9 @@ pub struct InputKeyHandler<'a> {
     pub search_tab: &'a mut TxTab,
     search_table: &'a mut TableData,
     search_txs: &'a mut TransactionData,
+    history_years: &'a mut IndexedData,
+    history_months: &'a mut IndexedData,
+    history_tab: &'a mut HistoryTab,
     total_tags: usize,
     chart_index: &'a mut Option<f64>,
     chart_hidden_mode: &'a mut bool,
@@ -86,6 +89,9 @@ impl<'a> InputKeyHandler<'a> {
         search_tab: &'a mut TxTab,
         search_table: &'a mut TableData,
         search_txs: &'a mut TransactionData,
+        history_years: &'a mut IndexedData,
+        history_months: &'a mut IndexedData,
+        history_tab: &'a mut HistoryTab,
         chart_index: &'a mut Option<f64>,
         chart_hidden_mode: &'a mut bool,
         summary_hidden_mode: &'a mut bool,
@@ -127,6 +133,9 @@ impl<'a> InputKeyHandler<'a> {
             search_tab,
             search_table,
             search_txs,
+            history_years,
+            history_months,
+            history_tab,
             total_tags,
             chart_index,
             chart_hidden_mode,
@@ -506,7 +515,17 @@ impl<'a> InputKeyHandler<'a> {
                     }
                 }
             }
-            CurrentUi::Initial | CurrentUi::History => {}
+            CurrentUi::History => match self.history_tab {
+                HistoryTab::Years => {
+                    self.history_months.set_index_zero();
+                    self.history_years.previous();
+                }
+                HistoryTab::Months => {
+                    self.history_months.previous();
+                }
+                HistoryTab::List => {}
+            },
+            CurrentUi::Initial => {}
         }
     }
 
@@ -563,7 +582,17 @@ impl<'a> InputKeyHandler<'a> {
                 }
                 SummaryTab::Table => {}
             },
-            CurrentUi::Initial | CurrentUi::History => {}
+            CurrentUi::History => match self.history_tab {
+                HistoryTab::Years => {
+                    self.history_months.set_index_zero();
+                    self.history_years.next();
+                }
+                HistoryTab::Months => {
+                    self.history_months.next();
+                }
+                HistoryTab::List => {}
+            },
+            CurrentUi::Initial => {}
         }
     }
 
@@ -576,7 +605,8 @@ impl<'a> InputKeyHandler<'a> {
             CurrentUi::Summary => self.do_summary_up(),
             CurrentUi::Chart => self.do_chart_up(),
             CurrentUi::Search => self.do_search_up(),
-            CurrentUi::Initial | CurrentUi::History => {}
+            CurrentUi::History => self.do_history_up(),
+            CurrentUi::Initial => {}
         }
         self.check_autofill();
     }
@@ -590,7 +620,8 @@ impl<'a> InputKeyHandler<'a> {
             CurrentUi::Summary => self.do_summary_down(),
             CurrentUi::Chart => self.do_chart_down(),
             CurrentUi::Search => self.do_search_down(),
-            CurrentUi::Initial | CurrentUi::History => {}
+            CurrentUi::History => self.do_history_down(),
+            CurrentUi::Initial => {}
         }
         self.check_autofill();
     }
@@ -901,7 +932,7 @@ impl<'a> InputKeyHandler<'a> {
                 // Do not select any table rows in the table section If
                 // there is no transaction
                 if self.all_tx_data.is_tx_empty() {
-                    *self.home_tab = self.home_tab.change_tab_up();
+                    *self.home_tab = self.home_tab.change_tab_down();
                 } else {
                     // Move to the selected value on table widget
                     // to the last row if pressed up on Year section
@@ -1624,6 +1655,32 @@ impl<'a> InputKeyHandler<'a> {
 
         if let Err(e) = status {
             self.search_data.add_tx_status(e.to_string());
+        }
+    }
+
+    #[cfg(not(tarpaulin_include))]
+    fn do_history_up(&mut self) {
+        match self.history_tab {
+            HistoryTab::Years => {
+                *self.history_tab = self.history_tab.change_tab_down();
+            }
+            HistoryTab::Months => {
+                *self.history_tab = self.history_tab.change_tab_up();
+            }
+            HistoryTab::List => todo!(),
+        }
+    }
+
+    #[cfg(not(tarpaulin_include))]
+    fn do_history_down(&mut self) {
+        match self.history_tab {
+            HistoryTab::Years => {
+                *self.history_tab = self.history_tab.change_tab_down();
+            }
+            HistoryTab::Months => {
+                *self.history_tab = self.history_tab.change_tab_up();
+            }
+            HistoryTab::List => todo!(),
         }
     }
 

--- a/src/key_checker/key_handler.rs
+++ b/src/key_checker/key_handler.rs
@@ -204,6 +204,11 @@ impl<'a> InputKeyHandler<'a> {
         self.reload_chart();
     }
 
+    #[cfg(not(tarpaulin_include))]
+    pub fn go_history(&mut self) {
+        *self.page = CurrentUi::History;
+    }
+
     /// Turns on help popup
     #[cfg(not(tarpaulin_include))]
     pub fn do_help_popup(&mut self) {
@@ -213,7 +218,7 @@ impl<'a> InputKeyHandler<'a> {
             CurrentUi::Chart => *self.popup = PopupState::ChartHelp,
             CurrentUi::Summary => *self.popup = PopupState::SummaryHelp,
             CurrentUi::Search => *self.popup = PopupState::SearchHelp,
-            CurrentUi::Initial => {}
+            CurrentUi::Initial | CurrentUi::History => {}
         }
     }
 
@@ -501,7 +506,7 @@ impl<'a> InputKeyHandler<'a> {
                     }
                 }
             }
-            CurrentUi::Initial => {}
+            CurrentUi::Initial | CurrentUi::History => {}
         }
     }
 
@@ -558,7 +563,7 @@ impl<'a> InputKeyHandler<'a> {
                 }
                 SummaryTab::Table => {}
             },
-            CurrentUi::Initial => {}
+            CurrentUi::Initial | CurrentUi::History => {}
         }
     }
 
@@ -571,7 +576,7 @@ impl<'a> InputKeyHandler<'a> {
             CurrentUi::Summary => self.do_summary_up(),
             CurrentUi::Chart => self.do_chart_up(),
             CurrentUi::Search => self.do_search_up(),
-            CurrentUi::Initial => {}
+            CurrentUi::Initial | CurrentUi::History => {}
         }
         self.check_autofill();
     }
@@ -585,7 +590,7 @@ impl<'a> InputKeyHandler<'a> {
             CurrentUi::Summary => self.do_summary_down(),
             CurrentUi::Chart => self.do_chart_down(),
             CurrentUi::Search => self.do_search_down(),
-            CurrentUi::Initial => {}
+            CurrentUi::Initial | CurrentUi::History => {}
         }
         self.check_autofill();
     }

--- a/src/key_checker/mod.rs
+++ b/src/key_checker/mod.rs
@@ -1,5 +1,6 @@
 mod add_tx_keys;
 mod chart_keys;
+mod history_keys;
 mod home_keys;
 mod initial_keys;
 mod key_handler;
@@ -8,6 +9,7 @@ mod summary_keys;
 
 pub use add_tx_keys::add_tx_keys;
 pub use chart_keys::chart_keys;
+pub use history_keys::history_keys;
 pub use home_keys::home_keys;
 pub use initial_keys::initial_keys;
 pub use key_handler::InputKeyHandler;

--- a/src/key_checker/search_keys.rs
+++ b/src/key_checker/search_keys.rs
@@ -22,6 +22,7 @@ pub fn search_keys(handler: &mut InputKeyHandler) -> Option<HandlingOutput> {
                 KeyCode::Char('x') => handler.change_search_date_type(),
                 KeyCode::Char('e') => handler.search_edit_tx(),
                 KeyCode::Char('d') => handler.do_deletion_popup(),
+                KeyCode::Char('y') => handler.go_history(),
                 KeyCode::Up => handler.handle_up_arrow(),
                 KeyCode::Down => handler.handle_down_arrow(),
                 KeyCode::Enter => handler.select_date_field(),

--- a/src/key_checker/summary_keys.rs
+++ b/src/key_checker/summary_keys.rs
@@ -17,6 +17,7 @@ pub fn summary_keys(handler: &mut InputKeyHandler) -> Option<HandlingOutput> {
             KeyCode::Char('h') => handler.do_help_popup(),
             KeyCode::Char('z') => handler.do_summary_hidden_mode(),
             KeyCode::Char('x') => handler.change_summary_sort(),
+            KeyCode::Char('y') => handler.go_history(),
             KeyCode::Right => handler.handle_right_arrow(),
             KeyCode::Left => handler.handle_left_arrow(),
             KeyCode::Up => handler.handle_up_arrow(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod add_tx_page;
 pub mod chart_page;
 pub mod db;
+mod history_page;
 pub mod home_page;
 mod initial_page;
 mod key_checker;

--- a/src/outputs/error.rs
+++ b/src/outputs/error.rs
@@ -1,8 +1,8 @@
 use rusqlite::Error as sqlError;
+use std::error::Error;
 use std::fmt::{self, Display, Result};
 use std::io::Error as ioError;
 use std::process::Output;
-use std::error::Error;
 
 #[derive(Debug)]
 pub enum TerminalExecutionError {

--- a/src/outputs/error.rs
+++ b/src/outputs/error.rs
@@ -1,17 +1,18 @@
 use rusqlite::Error as sqlError;
-use std::fmt;
-use std::io::Error;
+use std::fmt::{self, Display, Result};
+use std::io::Error as ioError;
 use std::process::Output;
+use std::error::Error;
 
 #[derive(Debug)]
 pub enum TerminalExecutionError {
     NotFound(Output),
-    ExecutionFailed(Error),
+    ExecutionFailed(ioError),
 }
 
-impl fmt::Display for TerminalExecutionError {
+impl Display for TerminalExecutionError {
     #[cfg(not(tarpaulin_include))]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         match self {
             TerminalExecutionError::NotFound(output) => write!(f, "Error while trying to run any console/terminal. Use a terminal/console to run the app. Output:\n\n{output:?}", ),
             TerminalExecutionError::ExecutionFailed(error) => write!(f, "Error while processing commands. Use a terminal/console to run the app. Output: {error}", ),
@@ -19,17 +20,17 @@ impl fmt::Display for TerminalExecutionError {
     }
 }
 
-impl std::error::Error for TerminalExecutionError {}
+impl Error for TerminalExecutionError {}
 
 #[derive(Debug)]
 pub enum UiHandlingError {
-    DrawingError(Error),
-    PollingError(Error),
+    DrawingError(ioError),
+    PollingError(ioError),
 }
 
-impl fmt::Display for UiHandlingError {
+impl Display for UiHandlingError {
     #[cfg(not(tarpaulin_include))]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         match self {
             UiHandlingError::DrawingError(err) => {
                 write!(f, "Error while trying to draw widgets. Error: {err}",)
@@ -41,7 +42,7 @@ impl fmt::Display for UiHandlingError {
     }
 }
 
-impl std::error::Error for UiHandlingError {}
+impl Error for UiHandlingError {}
 
 #[derive(Debug, PartialEq)]
 pub enum CheckingError {
@@ -52,9 +53,9 @@ pub enum CheckingError {
     SameTxMethod,
 }
 
-impl fmt::Display for CheckingError {
+impl Display for CheckingError {
     #[cfg(not(tarpaulin_include))]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         match self {
             CheckingError::EmptyDate => write!(f, "Date: Date cannot be empty"),
             CheckingError::EmptyMethod => write!(f, "Tx Method: TX Method cannot be empty"),
@@ -68,7 +69,7 @@ impl fmt::Display for CheckingError {
     }
 }
 
-impl std::error::Error for CheckingError {}
+impl Error for CheckingError {}
 
 #[derive(Debug, PartialEq)]
 pub enum SteppingError {
@@ -80,9 +81,9 @@ pub enum SteppingError {
     UnknownBValue,
 }
 
-impl fmt::Display for SteppingError {
+impl Display for SteppingError {
     #[cfg(not(tarpaulin_include))]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         match self {
             SteppingError::InvalidDate => {
                 write!(f, "Date: Failed to step due to invalid date format")
@@ -114,9 +115,9 @@ pub enum TxUpdateError {
     FailedDeleteTx(sqlError),
 }
 
-impl fmt::Display for TxUpdateError {
+impl Display for TxUpdateError {
     #[cfg(not(tarpaulin_include))]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         match self {
             TxUpdateError::FailedAddTx(e) => {
                 write!(

--- a/src/page_handler/ui_handler.rs
+++ b/src/page_handler/ui_handler.rs
@@ -126,7 +126,11 @@ pub fn start_app<B: Backend>(
         summary_years.index,
     ));
 
+    // data for the Search Page's table
     let mut search_table = TableData::new(Vec::new());
+
+    // data for the History Page's table
+    let mut history_table = TableData::new(history_data.get_txs());
 
     // the initial page REX loading index
     let mut starter_index = 0;
@@ -288,9 +292,14 @@ pub fn start_app<B: Backend>(
                         &mut search_table,
                         &search_date_type,
                     ),
-                    CurrentUi::History => {
-                        history_ui(f, &history_months, &history_years, &history_tab)
-                    }
+                    CurrentUi::History => history_ui(
+                        f,
+                        &history_months,
+                        &history_years,
+                        &history_tab,
+                        &history_data,
+                        &mut history_table,
+                    ),
                 }
                 popup_data.create_popup(f, &popup_state, &deletion_status);
             })
@@ -361,6 +370,8 @@ pub fn start_app<B: Backend>(
                 &mut history_years,
                 &mut history_months,
                 &mut history_tab,
+                &mut history_data,
+                &mut history_table,
                 &mut chart_index,
                 &mut chart_hidden_mode,
                 &mut summary_hidden_mode,

--- a/src/page_handler/ui_handler.rs
+++ b/src/page_handler/ui_handler.rs
@@ -9,11 +9,13 @@ use std::time::Duration;
 
 use crate::add_tx_page::add_tx_ui;
 use crate::chart_page::{chart_ui, ChartData};
+use crate::history_page::history_ui;
 use crate::home_page::home_ui;
 use crate::home_page::TransactionData;
 use crate::initial_page::initial_ui;
 use crate::key_checker::{
-    add_tx_keys, chart_keys, home_keys, initial_keys, search_keys, summary_keys, InputKeyHandler,
+    add_tx_keys, chart_keys, history_keys, home_keys, initial_keys, search_keys, summary_keys,
+    InputKeyHandler,
 };
 use crate::outputs::{HandlingOutput, UiHandlingError};
 use crate::page_handler::{
@@ -280,6 +282,7 @@ pub fn start_app<B: Backend>(
                         &mut search_table,
                         &search_date_type,
                     ),
+                    CurrentUi::History => history_ui(f),
                 }
                 popup_data.create_popup(f, &popup_state, &deletion_status);
             })
@@ -365,6 +368,7 @@ pub fn start_app<B: Backend>(
                 CurrentUi::Chart => chart_keys(&mut handler),
                 CurrentUi::Summary => summary_keys(&mut handler),
                 CurrentUi::Search => search_keys(&mut handler),
+                CurrentUi::History => history_keys(&mut handler),
             };
 
             if let Some(output) = status {

--- a/src/page_handler/ui_handler.rs
+++ b/src/page_handler/ui_handler.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use crate::add_tx_page::add_tx_ui;
 use crate::chart_page::{chart_ui, ChartData};
 use crate::history_page::history_ui;
+use crate::history_page::HistoryData;
 use crate::home_page::home_ui;
 use crate::home_page::TransactionData;
 use crate::initial_page::initial_ui;
@@ -28,8 +29,6 @@ use crate::summary_page::{summary_ui, SummaryData};
 use crate::tx_handler::TxData;
 use crate::utility::{get_all_tx_methods, get_empty_changes};
 
-// TODO: More colors? Needs to be turned into an array
-// and maintain an index for which color to select based on the scheme
 pub const BACKGROUND: Color = Color::Rgb(245, 245, 255);
 pub const TEXT: Color = Color::Rgb(153, 78, 236);
 pub const BOX: Color = Color::Rgb(255, 87, 51);
@@ -81,6 +80,8 @@ pub fn start_app<B: Backend>(
 
     // Stores all data relevant for home page such as balance, changes and txs
     let mut all_tx_data = TransactionData::new(home_months.index, home_years.index, conn);
+    // Stores all activity for a specific month of a year alongside the txs involved in an activity
+    let mut history_data = HistoryData::new(history_months.index, history_years.index, conn);
 
     let mut search_txs = TransactionData::new_search(Vec::new(), Vec::new());
     // data for the Home Page's tx table

--- a/src/page_handler/ui_handler.rs
+++ b/src/page_handler/ui_handler.rs
@@ -19,8 +19,8 @@ use crate::key_checker::{
 };
 use crate::outputs::{HandlingOutput, UiHandlingError};
 use crate::page_handler::{
-    ChartTab, CurrentUi, DateType, DeletionStatus, HomeTab, IndexedData, PopupState, SortingType,
-    SummaryTab, TableData, TxTab,
+    ChartTab, CurrentUi, DateType, DeletionStatus, HistoryTab, HomeTab, IndexedData, PopupState,
+    SortingType, SummaryTab, TableData, TxTab,
 };
 use crate::popup_page::PopupData;
 use crate::search_page::search_ui;
@@ -65,6 +65,10 @@ pub fn start_app<B: Backend>(
     let mut summary_years = IndexedData::new_yearly();
     // contains the summary page mode selection list that is indexed
     let mut summary_modes = IndexedData::new_modes();
+    // contains the History page month list that is indexed
+    let mut history_years = IndexedData::new_yearly();
+    // contains the History page month list that is indexed
+    let mut history_months = IndexedData::new_monthly();
 
     // the selected widget on the Home Page. Default set to the month selection
     let mut home_tab = HomeTab::Months;
@@ -101,6 +105,7 @@ pub fn start_app<B: Backend>(
     let mut search_tab = TxTab::Nothing;
     // Store the current searching date type
     let mut search_date_type = DateType::Exact;
+    let mut history_tab = HistoryTab::Years;
 
     // Holds the data that will be/are inserted into the Add Tx page's input fields
     let mut add_tx_data = TxData::new();
@@ -282,7 +287,9 @@ pub fn start_app<B: Backend>(
                         &mut search_table,
                         &search_date_type,
                     ),
-                    CurrentUi::History => history_ui(f),
+                    CurrentUi::History => {
+                        history_ui(f, &history_months, &history_years, &history_tab)
+                    }
                 }
                 popup_data.create_popup(f, &popup_state, &deletion_status);
             })
@@ -350,6 +357,9 @@ pub fn start_app<B: Backend>(
                 &mut search_tab,
                 &mut search_table,
                 &mut search_txs,
+                &mut history_years,
+                &mut history_months,
+                &mut history_tab,
                 &mut chart_index,
                 &mut chart_hidden_mode,
                 &mut summary_hidden_mode,

--- a/src/page_handler/ui_handler.rs
+++ b/src/page_handler/ui_handler.rs
@@ -316,7 +316,7 @@ pub fn start_app<B: Backend>(
                 }
             }
             CurrentUi::Chart => {
-                // If chart animation has ended, start polling 
+                // If chart animation has ended, start polling
                 if chart_index.is_some()
                     && !poll(Duration::from_millis(2)).map_err(UiHandlingError::PollingError)?
                 {

--- a/src/page_handler/ui_state.rs
+++ b/src/page_handler/ui_state.rs
@@ -168,6 +168,7 @@ pub enum CurrentUi {
     Chart,
     Summary,
     Search,
+    History,
 }
 
 /// Indicates which popup is currently on and is being shown in the screen

--- a/src/page_handler/ui_state.rs
+++ b/src/page_handler/ui_state.rs
@@ -471,7 +471,7 @@ impl ActivityType {
 
     pub fn to_details(&self) -> String {
         match self {
-            Self::NewTX => String::from("A new Transaction was added with"),
+            Self::NewTX => String::from("A new Transaction was added"),
             Self::EditTX(id) => format!("A transaction was edited with ID {}", id.unwrap()),
             Self::DeleteTX(id) => format!("A transaction was deleted with ID {}", id.unwrap()),
             Self::IDNumSwap(id_1, id_2) => format!(
@@ -481,9 +481,9 @@ impl ActivityType {
             ),
             Self::SearchTX(total) => {
                 if total.unwrap() == 1 {
-                    format!("Transactions were searched with one field")
+                    String::from("Transactions were searched with one field")
                 } else {
-                    format!("Transactions were searched with multiple fields")
+                    String::from("Transactions were searched with multiple fields")
                 }
             }
         }

--- a/src/page_handler/ui_state.rs
+++ b/src/page_handler/ui_state.rs
@@ -451,8 +451,51 @@ impl HistoryTab {
 
 pub enum ActivityType {
     NewTX,
-    EditTX,
-    DeleteTX,
-    IDNumSwap,
-    SearchTX,
+    EditTX(Option<i32>),
+    DeleteTX(Option<i32>),
+    IDNumSwap(Option<i32>, Option<i32>),
+    SearchTX(Option<u8>),
+}
+
+impl ActivityType {
+    pub fn from_str(data: &str) -> Self {
+        match data {
+            "Add TX" => Self::NewTX,
+            "Edit TX" => Self::EditTX(None),
+            "Delete TX" => Self::DeleteTX(None),
+            "TX Position Swap" => Self::IDNumSwap(None, None),
+            "Search TX" => Self::SearchTX(None),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn to_details(&self) -> String {
+        match self {
+            Self::NewTX => String::from("A new Transaction was added with"),
+            Self::EditTX(id) => format!("A transaction was edited with ID {}", id.unwrap()),
+            Self::DeleteTX(id) => format!("A transaction was deleted with ID {}", id.unwrap()),
+            Self::IDNumSwap(id_1, id_2) => format!(
+                "Transaction with ID num {} and ID num {} was swapped",
+                id_1.unwrap(),
+                id_2.unwrap()
+            ),
+            Self::SearchTX(total) => {
+                if total.unwrap() == 1 {
+                    format!("Transactions were searched with one field")
+                } else {
+                    format!("Transactions were searched with multiple fields")
+                }
+            }
+        }
+    }
+
+    pub fn to_str(&self) -> String {
+        match self {
+            Self::NewTX => String::from("Add TX"),
+            Self::EditTX(_) => String::from("Edit TX"),
+            Self::DeleteTX(_) => String::from("Delete TX"),
+            Self::IDNumSwap(_, _) => String::from("TX Position Swap"),
+            Self::SearchTX(_) => String::from("Search TX"),
+        }
+    }
 }

--- a/src/page_handler/ui_state.rs
+++ b/src/page_handler/ui_state.rs
@@ -323,8 +323,14 @@ pub enum UserInputType {
     RepositionTxMethod(Vec<String>),
     SetNewLocation(PathBuf),
     CancelledOperation,
+    ResetData(ResetType),
     BackupDBPath(Vec<PathBuf>),
     InvalidInput,
+}
+
+pub enum ResetType {
+    NewLocation,
+    BackupDB,
 }
 
 impl UserInputType {
@@ -415,4 +421,38 @@ impl HomeRow {
             HomeRow::TopRow
         }
     }
+}
+
+pub enum HistoryTab {
+    Years,
+    Months,
+    List,
+}
+
+impl HistoryTab {
+    #[cfg(not(tarpaulin_include))]
+    pub fn change_tab_up(&mut self) -> Self {
+        match &self {
+            HistoryTab::Years => HistoryTab::List,
+            HistoryTab::Months => HistoryTab::Years,
+            HistoryTab::List => HistoryTab::Months,
+        }
+    }
+
+    #[cfg(not(tarpaulin_include))]
+    pub fn change_tab_down(&mut self) -> Self {
+        match &self {
+            HistoryTab::List => HistoryTab::Years,
+            HistoryTab::Years => HistoryTab::Months,
+            HistoryTab::Months => HistoryTab::List,
+        }
+    }
+}
+
+pub enum ActivityType {
+    NewTX,
+    EditTX,
+    DeleteTX,
+    IDNumSwap,
+    SearchTX,
 }

--- a/src/search_page/search_ui.rs
+++ b/src/search_page/search_ui.rs
@@ -310,6 +310,12 @@ pub fn search_ui(
         }
     }
 
+    if let Some(index) = search_table.state.selected() {
+        if index > 7 {
+            *search_table.state.offset_mut() = index - 7;
+        }
+    }
+
     // render the previously generated data into an interface
     f.render_widget(details_sec, chunks[1]);
     f.render_widget(status_sec, chunks[2]);

--- a/src/search_page/search_ui.rs
+++ b/src/search_page/search_ui.rs
@@ -146,7 +146,7 @@ pub fn search_ui(
     // to be at the top which is the final value of the vector.
     for i in status_data.iter().rev() {
         let (initial, rest) = i.split_once(':').unwrap();
-        if !i.contains("Accepted") && !i.contains("Nothing") {
+        if !i.contains("Accepted") && !i.contains("Nothing") && !i.contains("Search: Found") {
             status_text.push(Line::from(vec![
                 Span::styled(
                     initial,
@@ -311,8 +311,8 @@ pub fn search_ui(
     }
 
     if let Some(index) = search_table.state.selected() {
-        if index > 7 {
-            *search_table.state.offset_mut() = index - 7;
+        if index > 10 {
+            *search_table.state.offset_mut() = index - 10;
         }
     }
 

--- a/src/summary_page/summary_ui.rs
+++ b/src/summary_page/summary_ui.rs
@@ -359,6 +359,13 @@ pub fn summary_ui(
         }
     }
 
+    // Always keep some items rendered on the upper side of the table
+    if let Some(index) = table_data.state.selected() {
+        if index > 7 {
+            *table_data.state.offset_mut() = index - 7;
+        }
+    }
+
     if summary_hidden_mode {
         f.render_stateful_widget(summary_area_1, left_summary[0], &mut summary_table_1.state);
         f.render_stateful_widget(summary_area_2, left_summary[1], &mut summary_table_2.state);

--- a/src/tx_handler/tx_data.rs
+++ b/src/tx_handler/tx_data.rs
@@ -735,7 +735,7 @@ impl TxData {
     }
 
     /// Add a previously deleted tx again but with a new `id_num`
-    pub fn switch_tx_id(&self, new_id: i32, conn: &mut Connection) {
+    pub fn switch_tx_id(&self, new_id: i32, activity_num: i32, conn: &mut Connection) {
         add_tx(
             &self.date,
             &self.details,
@@ -747,5 +747,19 @@ impl TxData {
             conn,
         )
         .unwrap();
+
+        add_new_activity_tx(
+            vec![
+                &self.date,
+                &self.details,
+                &self.get_tx_method(),
+                &self.amount,
+                &self.tx_type,
+                &self.tags,
+                &new_id.to_string(),
+            ],
+            activity_num,
+            conn,
+        );
     }
 }

--- a/src/tx_handler/tx_data.rs
+++ b/src/tx_handler/tx_data.rs
@@ -230,8 +230,8 @@ impl TxData {
                         &self.tags,
                         &id_num,
                     ];
-                    add_new_activity_tx(new_tx, activity_num, conn);
-                    add_new_activity_tx(deleted_tx, activity_num, conn);
+                    add_new_activity_tx(&new_tx, activity_num, conn);
+                    add_new_activity_tx(&deleted_tx, activity_num, conn);
                     Ok(())
                 }
                 Err(e) => Err(TxUpdateError::FailedEditTx(e).to_string()),
@@ -251,7 +251,7 @@ impl TxData {
                 Ok(()) => {
                     let activity_num = add_new_activity(ActivityType::NewTX, conn);
                     let last_tx = get_last_tx(conn);
-                    add_new_activity_tx(last_tx, activity_num, conn);
+                    add_new_activity_tx(&last_tx, activity_num, conn);
                     Ok(())
                 }
                 Err(e) => Err(TxUpdateError::FailedAddTx(e).to_string()),
@@ -749,7 +749,7 @@ impl TxData {
         .unwrap();
 
         add_new_activity_tx(
-            vec![
+            &[
                 &self.date,
                 &self.details,
                 &self.get_tx_method(),

--- a/src/tx_handler/tx_data.rs
+++ b/src/tx_handler/tx_data.rs
@@ -6,11 +6,12 @@ use crate::outputs::{
     CheckingError, ComparisonType, NAType, StepType, SteppingError, TxType, TxUpdateError,
     VerifyingOutput,
 };
-use crate::page_handler::{DateType, TxTab};
+use crate::page_handler::{ActivityType, DateType, TxTab};
 use crate::tx_handler::{add_tx, delete_tx};
 use crate::utility::traits::{AutoFiller, DataVerifier, FieldStepper};
 use crate::utility::{
-    add_char_to, check_comparison, get_all_tx_methods, get_last_balances, get_search_data,
+    add_char_to, add_new_activity, add_new_activity_tx, check_comparison, get_all_tx_methods,
+    get_last_balances, get_search_data,
 };
 
 /// Contains all data for a Transaction to work
@@ -197,7 +198,7 @@ impl TxData {
             // how saving an edited tx works
             // delete the tx that was being edited from the db using the id_num ->
             // add another tx using the new data but take the earlier id to add to the db
-
+            // TODO a new method to fetch one tx from the db using id num. Need both old and the new status
             let status = delete_tx(self.id_num, conn);
             match status {
                 Ok(()) => {}
@@ -216,7 +217,12 @@ impl TxData {
             );
 
             match status_add {
-                Ok(()) => Ok(()),
+                Ok(()) => {
+                    let activity_num =
+                        add_new_activity(ActivityType::EditTX(Some(self.id_num)), conn);
+                    add_new_activity_tx(self.get_all_texts(), activity_num, conn);
+                    Ok(())
+                }
                 Err(e) => Err(TxUpdateError::FailedEditTx(e).to_string()),
             }
         } else {
@@ -231,7 +237,11 @@ impl TxData {
                 conn,
             );
             match status {
-                Ok(()) => Ok(()),
+                Ok(()) => {
+                    let activity_num = add_new_activity(ActivityType::NewTX, conn);
+                    add_new_activity_tx(self.get_all_texts(), activity_num, conn);
+                    Ok(())
+                }
                 Err(e) => Err(TxUpdateError::FailedAddTx(e).to_string()),
             }
         }

--- a/src/utility/sub_func.rs
+++ b/src/utility/sub_func.rs
@@ -137,7 +137,7 @@ pub fn get_all_txs(
     // preparing the query for db, getting current month's all transactions
     let mut statement = conn
         .prepare(
-            "SELECT * FROM tx_all Where date BETWEEN date(?) AND date(?) ORDER BY date, id_num",
+            "SELECT * FROM tx_all WHERE date BETWEEN date(?) AND date(?) ORDER BY date, id_num",
         )
         .expect("could not prepare statement");
 
@@ -1013,8 +1013,11 @@ pub fn switch_tx_index(
 
     delete_tx(id_1, conn).unwrap();
     delete_tx(id_2, conn).unwrap();
-    tx_data_1.switch_tx_id(id_2, conn);
-    tx_data_2.switch_tx_id(id_1, conn);
+
+    let activity_num = add_new_activity(ActivityType::IDNumSwap(Some(id_1), Some(id_2)), conn);
+
+    tx_data_1.switch_tx_id(id_2, activity_num, conn);
+    tx_data_2.switch_tx_id(id_1, activity_num, conn);
 }
 
 pub fn get_all_activities(

--- a/src/utility/sub_func.rs
+++ b/src/utility/sub_func.rs
@@ -957,7 +957,7 @@ pub fn get_search_data(
     let search_data = vec![date, details, &tx_method, amount, tx_type, tags, ""];
 
     let activity_num = add_new_activity(activity_type, conn);
-    add_new_activity_tx(search_data, activity_num, conn);
+    add_new_activity_tx(&search_data, activity_num, conn);
 
     (all_txs, all_ids)
 }

--- a/src/utility/sub_func.rs
+++ b/src/utility/sub_func.rs
@@ -818,8 +818,12 @@ pub fn get_search_data(
     let mut all_txs = Vec::new();
     let mut all_ids = Vec::new();
 
-    let tx_method = if tx_type == "Transfer" {
+    let tx_method = if tx_type == "Transfer" && !from_method.is_empty() && !to_method.is_empty() {
         format!("{from_method} to {to_method}").trim().to_string()
+    } else if tx_type == "Transfer" && !from_method.is_empty() && to_method.is_empty() {
+        format!("{from_method} to ?").trim().to_string()
+    } else if tx_type == "Transfer" && from_method.is_empty() && !to_method.is_empty() {
+        format!("? to {to_method}").trim().to_string()
     } else if from_method.is_empty() && to_method.is_empty() {
         String::new()
     } else {

--- a/src/utility/utils.rs
+++ b/src/utility/utils.rs
@@ -727,6 +727,9 @@ pub fn reverse_date_format(date: String) -> String {
         return date;
     }
     let collected_date = date.split('-').collect::<Vec<&str>>();
+    if collected_date.len() != 3 {
+        return date;
+    }
     let new_date = format!(
         "{}-{}-{}",
         collected_date[2], collected_date[1], collected_date[0]

--- a/src/utility/utils.rs
+++ b/src/utility/utils.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::error::Error;
 use std::fs::{self, File};
-use std::io::{stdout, Read, Stdout, Write};
+use std::io::{stdout, Read, Result as ioResult, Stdout, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{process, thread};
@@ -336,6 +336,7 @@ pub fn start_timer<T: std::fmt::Display>(input: T) {
         handle.flush().unwrap();
         thread::sleep(Duration::from_millis(1000));
     }
+    println!("\n");
 }
 
 /// Takes a user input and returns the trimmed input as String
@@ -505,8 +506,8 @@ pub fn create_change_location_file(working_dir: &PathBuf, new_path: &Path) {
 }
 
 /// Create a `backup_paths.json` file to store the location of where backup db will be located
-pub fn create_backup_location_file(working_dir: &PathBuf, backup_paths: Vec<PathBuf>) {
-    let mut target_dir = working_dir.to_owned();
+pub fn create_backup_location_file(original_db_path: &PathBuf, backup_paths: Vec<PathBuf>) {
+    let mut target_dir = original_db_path.to_owned();
     target_dir.pop();
 
     let backup = BackupPaths {
@@ -552,4 +553,30 @@ pub fn save_backup_db(db_path: &PathBuf, original_db_path: &PathBuf) {
             continue;
         }
     }
+}
+
+pub fn delete_backup_db(original_db_path: &PathBuf) -> ioResult<()> {
+    let mut json_path = original_db_path.to_owned();
+    json_path.pop();
+
+    json_path.push("backup_paths.json");
+
+    if !json_path.exists() {
+        return Ok(());
+    }
+
+    fs::remove_file(json_path)
+}
+
+pub fn delete_location_change(original_db_path: &PathBuf) -> ioResult<()> {
+    let mut json_path = original_db_path.to_owned();
+    json_path.pop();
+
+    json_path.push("location.json");
+
+    if !json_path.exists() {
+        return Ok(());
+    }
+
+    fs::remove_file(json_path)
 }

--- a/src/utility/utils.rs
+++ b/src/utility/utils.rs
@@ -694,7 +694,7 @@ pub fn add_new_activity(activity_type: ActivityType, conn: &Connection) -> i32 {
 }
 
 pub fn add_new_activity_tx<T: AsRef<str> + Display>(
-    tx_data: Vec<T>,
+    tx_data: &[T],
     activity_num: i32,
     conn: &Connection,
 ) {

--- a/src/utility/utils.rs
+++ b/src/utility/utils.rs
@@ -21,7 +21,8 @@ use strsim::normalized_levenshtein;
 use crate::db::{add_tags_column, create_db, migrate_to_activities, update_balance_type, YEARS};
 use crate::outputs::ComparisonType;
 use crate::page_handler::{
-    DateType, IndexedData, SortingType, UserInputType, BACKGROUND, BOX, HIGHLIGHTED, TEXT,
+    ActivityType, DateType, IndexedData, SortingType, UserInputType, BACKGROUND, BOX, HIGHLIGHTED,
+    TEXT,
 };
 use crate::utility::get_user_tx_methods;
 
@@ -607,3 +608,13 @@ pub fn delete_location_change(original_db_path: &PathBuf) -> ioResult<()> {
 
     fs::remove_file(json_path)
 }
+
+// NOTE activity tx fetching must be done using the first and last activity num gotten
+// NOTE activity num fetching should happen with date value, activity tx fetching will happen based on what id numbers we get
+
+pub fn add_new_activity(activity_type: ActivityType, conn: &Connection) -> i32 {
+    // TODO add a new activity and get the activity num of the new activity
+    todo!()
+}
+
+pub fn add_new_activity_tx(tx_data: Vec<&str>, activity_num: i32, conn: &Connection) {}

--- a/src/utility/utils.rs
+++ b/src/utility/utils.rs
@@ -1,4 +1,4 @@
-use chrono::Local;
+use chrono::{Local, Months, NaiveDate};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen,
@@ -157,8 +157,14 @@ pub fn get_sql_dates(month: usize, year: usize, date_type: &DateType) -> (String
     match date_type {
         DateType::Monthly => {
             let datetime_1 = format!("{}-{:02}-01", YEARS[year], month + 1);
-            let datetime_2 = format!("{}-{:02}-31", YEARS[year], month + 1);
-            (datetime_1, datetime_2)
+            let last_date =
+                NaiveDate::from_ymd_opt(YEARS[year].parse().unwrap(), (month + 1) as u32, 1)
+                    .unwrap()
+                    .checked_add_months(Months::new(1))
+                    .unwrap()
+                    .pred_opt()
+                    .unwrap();
+            (datetime_1, last_date.to_string())
         }
         DateType::Yearly => {
             let datetime_1 = format!("{}-01-01", YEARS[year]);

--- a/src/utility/utils.rs
+++ b/src/utility/utils.rs
@@ -700,11 +700,30 @@ pub fn add_new_activity_tx<T: AsRef<str> + Display>(
     let tags = &tx_data[5];
     let id_num = &tx_data[6];
 
+    let mut string_date = date.to_string();
+    let splitted_date = string_date.split('-').collect::<Vec<&str>>();
+
+    if splitted_date[0].len() == 2 {
+        string_date = reverse_date_format(string_date);
+    }
+
     let query = format!(
         r#"INSERT INTO activity_txs 
     (date, details, tx_method, amount, tx_type, tags, id_num, activity_num)
-    VALUES ("{date}", "{details}", "{tx_method}", "{amount}", "{tx_type}", "{tags}", "{id_num}", "{activity_num}")"#
+    VALUES ("{string_date}", "{details}", "{tx_method}", "{amount}", "{tx_type}", "{tags}", "{id_num}", "{activity_num}")"#
     );
 
     conn.execute(&query, []).unwrap();
+}
+
+pub fn reverse_date_format(date: String) -> String {
+    if date.is_empty() {
+        return date;
+    }
+    let collected_date = date.split('-').collect::<Vec<&str>>();
+    let new_date = format!(
+        "{}-{}-{}",
+        collected_date[2], collected_date[1], collected_date[0]
+    );
+    new_date
 }


### PR DESCRIPTION
Resolves #62 

* Removed some useless debug impl
* 4th and 5th options on J press can now be reset on empty input
* Home table scrolling is now done with offset to the selected index remains near the middle of the screen, always
* Fixed search tx not working properly on transfer tx type when either from or to methods are empty
* Add, edit, delete, search tx and tx position swap now records the activity 
* Datetime when fetching tx is now more accurate, fixing a bug of giving an extra row
* History UI page