### PR TITLE
Add daily income and expense rows

### DIFF
--- a/src/add_tx_page/add_tx_ui.rs
+++ b/src/add_tx_page/add_tx_ui.rs
@@ -34,17 +34,14 @@ pub fn add_tx_ui(f: &mut Frame, add_tx_data: &TxData, add_tx_tab: &TxTab) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints(
-            [
-                // input chunk
-                Constraint::Length(3),
-                // details input chunk
-                Constraint::Length(3),
-                // status chunk
-                Constraint::Percentage(100),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            // input chunk
+            Constraint::Length(3),
+            // details input chunk
+            Constraint::Length(3),
+            // status chunk
+            Constraint::Percentage(100),
+        ])
         .split(size);
 
     // based on the tx type divide the first chunk into 5 or 6 parts horizontally
@@ -53,30 +50,24 @@ pub fn add_tx_ui(f: &mut Frame, add_tx_data: &TxData, add_tx_tab: &TxTab) {
         match tx_type {
             TxType::IncomeExpense => Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints(
-                    [
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(20),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                ])
                 .split(chunks[0]),
             TxType::Transfer => Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints(
-                    [
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(20),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(20),
+                ])
                 .split(chunks[0]),
         }
     };

--- a/src/chart_page/chart_ui.rs
+++ b/src/chart_page/chart_ui.rs
@@ -31,33 +31,26 @@ pub fn chart_ui(
 
     // don't create any other chunk if hidden mode is enabled. Create 1 chunk that will be used for the chart itself
     if chart_hidden_mode {
-        main_layout = main_layout.constraints([Constraint::Min(0)].as_ref());
+        main_layout = main_layout.constraints([Constraint::Min(0)]);
     } else {
         match mode_selection.index {
             0 => {
-                main_layout = main_layout.constraints(
-                    [
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Min(0),
-                    ]
-                    .as_ref(),
-                );
+                main_layout = main_layout.constraints([
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Min(0),
+                ]);
             }
             1 => {
-                main_layout = main_layout.constraints(
-                    [
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Min(0),
-                    ]
-                    .as_ref(),
-                );
+                main_layout = main_layout.constraints([
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Min(0),
+                ]);
             }
             2 => {
-                main_layout =
-                    main_layout.constraints([Constraint::Length(3), Constraint::Min(0)].as_ref());
+                main_layout = main_layout.constraints([Constraint::Length(3), Constraint::Min(0)]);
             }
             _ => {}
         };
@@ -76,7 +69,7 @@ pub fn chart_ui(
 
     let all_tx_methods = get_all_tx_methods(conn);
 
-    // a vector containing another vector with vec![X, Y] coordinate of where to render chart points
+    // a vector containing another vector vec![X, Y] with coordinate of where to render chart points
     let mut datasets: Vec<Vec<(f64, f64)>> = Vec::new();
     let mut last_balances = Vec::new();
 
@@ -318,8 +311,6 @@ pub fn chart_ui(
         );
 
     match current_page {
-        // previously added a black block to year and month widget if a value is not selected
-        // Now we will turn that black block into green if a value is selected
         ChartTab::Months => {
             month_tab = month_tab
                 .highlight_style(Style::default().add_modifier(Modifier::BOLD).bg(SELECTED));

--- a/src/history_page/history_ui.rs
+++ b/src/history_page/history_ui.rs
@@ -78,15 +78,12 @@ pub fn history_ui(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints(
-            [
-                Constraint::Length(3),
-                Constraint::Length(3),
-                Constraint::Min(0),
-                Constraint::Length(5),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(5),
+        ])
         .split(size);
 
     f.render_widget(main_block(), size);

--- a/src/home_page/home_ui.rs
+++ b/src/home_page/home_ui.rs
@@ -10,6 +10,16 @@ use crate::page_handler::{
 };
 use crate::utility::{create_tab, get_all_tx_methods, main_block, styled_block};
 
+const BALANCE_BOLD: [&str; 7] = [
+    "Balance",
+    "Changes",
+    "Total",
+    "Income",
+    "Expense",
+    "Daily Income",
+    "Daily Expense",
+];
+
 /// The function draws the Home page of the interface.
 #[cfg(not(tarpaulin_include))]
 pub fn home_ui(
@@ -89,15 +99,12 @@ pub fn home_ui(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints(
-            [
-                Constraint::Length(9),
-                Constraint::Length(3),
-                Constraint::Length(3),
-                Constraint::Min(0),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Length(9),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
         .split(size);
 
     f.render_widget(main_block(), size);
@@ -204,12 +211,14 @@ pub fn home_ui(
                     HomeRow::TopRow => unreachable!(),
                 };
 
+                // Changes row can contain arrow symbols
                 let symbol = if c.contains('↑') || c.contains('↓') {
                     c.chars().next()
                 } else {
                     None
                 };
 
+                // If loading was complete then this value is to be shown
                 let actual_data: f64 = if row_type != HomeRow::Changes {
                     c.parse().unwrap()
                 } else if let Some(sym) = symbol {
@@ -266,8 +275,6 @@ pub fn home_ui(
                         HomeRow::TopRow => unreachable!(),
                         _ => *load_data = last_data - (difference * *load_percentage),
                     }
-                } else {
-                    *load_data = actual_data;
                 }
 
                 // 100% has been reached, show the actual balance to the UI now
@@ -275,9 +282,9 @@ pub fn home_ui(
                     *load_data = actual_data;
                 }
 
-                if row_type != HomeRow::Changes {
-                    format!("{load_data:.2}").separate_with_commas()
-                } else if let Some(sym) = symbol {
+                // re-add the previously removed symbol if is the Changes row
+                // Otherwise separate the number with commas
+                if let Some(sym) = symbol {
                     format!("{sym}{load_data:.2}",).separate_with_commas()
                 } else {
                     format!("{load_data:.2}").separate_with_commas()
@@ -290,15 +297,7 @@ pub fn home_ui(
                 Cell::from(c).style(Style::default().fg(BLUE))
             } else if c.contains('↓') {
                 Cell::from(c).style(Style::default().fg(RED))
-            } else if all_methods.contains(&c)
-                || c == "Balance"
-                || c == "Changes"
-                || c == "Total"
-                || c == "Income"
-                || c == "Expense"
-                || c == "Daily Income"
-                || c == "Daily Expense"
-            {
+            } else if all_methods.contains(&c) || BALANCE_BOLD.contains(&c.as_str()) {
                 Cell::from(c).style(Style::default().add_modifier(Modifier::BOLD))
             } else {
                 Cell::from(c)

--- a/src/initial_page/initial_ui.rs
+++ b/src/initial_page/initial_ui.rs
@@ -14,14 +14,11 @@ pub fn initial_ui(f: &mut Frame, start_from: usize) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints(
-            [
-                Constraint::Length(8),
-                Constraint::Length(1),
-                Constraint::Min(5),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Length(8),
+            Constraint::Length(1),
+            Constraint::Min(5),
+        ])
         .split(size);
 
     let horizontal_help_chunks = Layout::default()

--- a/src/key_checker/key_handler.rs
+++ b/src/key_checker/key_handler.rs
@@ -61,6 +61,8 @@ pub struct InputKeyHandler<'a> {
     ongoing_changes: &'a mut Vec<String>,
     ongoing_income: &'a mut Vec<String>,
     ongoing_expense: &'a mut Vec<String>,
+    daily_ongoing_income: &'a mut Vec<String>,
+    daily_ongoing_expense: &'a mut Vec<String>,
     conn: &'a mut Connection,
 }
 
@@ -107,6 +109,8 @@ impl<'a> InputKeyHandler<'a> {
         ongoing_changes: &'a mut Vec<String>,
         ongoing_income: &'a mut Vec<String>,
         ongoing_expense: &'a mut Vec<String>,
+        daily_ongoing_income: &'a mut Vec<String>,
+        daily_ongoing_expense: &'a mut Vec<String>,
         conn: &'a mut Connection,
     ) -> InputKeyHandler<'a> {
         let total_tags = summary_data
@@ -154,6 +158,8 @@ impl<'a> InputKeyHandler<'a> {
             ongoing_changes,
             ongoing_income,
             ongoing_expense,
+            daily_ongoing_income,
+            daily_ongoing_expense,
             conn,
         }
     }
@@ -1592,6 +1598,8 @@ impl<'a> InputKeyHandler<'a> {
         *self.ongoing_changes = vec![String::from("0.0"); balance_data.len()];
         *self.ongoing_expense = balance_data.clone();
         *self.ongoing_income = balance_data.clone();
+        *self.daily_ongoing_expense = balance_data.clone();
+        *self.daily_ongoing_income = balance_data.clone();
     }
 
     #[cfg(not(tarpaulin_include))]

--- a/src/page_handler/ui_handler.rs
+++ b/src/page_handler/ui_handler.rs
@@ -158,7 +158,7 @@ pub fn start_app<B: Backend>(
     let mut ongoing_balance = Vec::new();
     // If the difference between the ongoing and last balance is 100, each loop it adds/reduces x.xx% of the difference to the balance
     // till actual balance is reached. After each loop it gets increased by a little till 1.0 and key polling starts at 1.0, putting the app to sleep
-    // Also used for the changes row
+    // A single var is used to keep track of load % for all values on the home page
     let mut load_percentage = 0.0;
 
     // Works similarly to balance load

--- a/src/page_handler/ui_state.rs
+++ b/src/page_handler/ui_state.rs
@@ -404,6 +404,8 @@ pub enum HomeRow {
     Changes,
     Income,
     Expense,
+    DailyIncome,
+    DailyExpense,
     TopRow,
 }
 
@@ -418,6 +420,10 @@ impl HomeRow {
             HomeRow::Income
         } else if data[0] == "Expense" {
             HomeRow::Expense
+        } else if data[0] == "Daily Income" {
+            HomeRow::DailyIncome
+        } else if data[0] == "Daily Expense" {
+            HomeRow::DailyExpense
         } else {
             HomeRow::TopRow
         }

--- a/src/popup_page/popup_ui.rs
+++ b/src/popup_page/popup_ui.rs
@@ -26,7 +26,7 @@ pub fn create_popup(f: &mut Frame, x_value: u16, y_value: u16, title: &str, text
     let new_chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints([Constraint::Min(1), Constraint::Length(1)].as_ref())
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(area);
 
     f.render_widget(Clear, area);
@@ -73,13 +73,13 @@ pub fn create_deletion_popup(f: &mut Frame, deletion_status: &DeletionStatus) {
     let new_chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints([Constraint::Min(1), Constraint::Length(5)].as_ref())
+        .constraints([Constraint::Min(1), Constraint::Length(5)])
         .split(area);
 
     let selection_chunk = Layout::default()
         .direction(Direction::Horizontal)
         .margin(2)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(new_chunks[1]);
 
     f.render_widget(Clear, area);
@@ -133,25 +133,19 @@ pub fn create_deletion_popup(f: &mut Frame, deletion_status: &DeletionStatus) {
 fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
     let popup_layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(
-            [
-                Constraint::Percentage((100 - percent_y) / 2),
-                Constraint::Percentage(percent_y),
-                Constraint::Percentage((100 - percent_y) / 2),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
         .split(r);
 
     Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(
-            [
-                Constraint::Percentage((100 - percent_x) / 2),
-                Constraint::Percentage(percent_x),
-                Constraint::Percentage((100 - percent_x) / 2),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
         .split(popup_layout[1])[1]
 }

--- a/src/search_page/search_ui.rs
+++ b/src/search_page/search_ui.rs
@@ -74,19 +74,16 @@ pub fn search_ui(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(2)
-        .constraints(
-            [
-                // input chunk
-                Constraint::Length(3),
-                // details input chunk
-                Constraint::Length(3),
-                // status chunk
-                Constraint::Length(10),
-                // Transaction list chunk,
-                Constraint::Min(0),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            // input chunk
+            Constraint::Length(3),
+            // details input chunk
+            Constraint::Length(3),
+            // status chunk
+            Constraint::Length(10),
+            // Transaction list chunk,
+            Constraint::Min(0),
+        ])
         .split(size);
 
     // based on the tx type divide the first chunk into 5 or 6 parts horizontally
@@ -95,30 +92,24 @@ pub fn search_ui(
         match tx_type {
             TxType::IncomeExpense => Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints(
-                    [
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(20),
-                        Constraint::Percentage(20),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(20),
+                ])
                 .split(chunks[0]),
             TxType::Transfer => Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints(
-                    [
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(16),
-                        Constraint::Percentage(20),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(16),
+                    Constraint::Percentage(20),
+                ])
                 .split(chunks[0]),
         }
     };

--- a/src/summary_page/summary_ui.rs
+++ b/src/summary_page/summary_ui.rs
@@ -92,57 +92,45 @@ pub fn summary_ui(
     let mut summary_layout = Layout::default().direction(Direction::Horizontal);
 
     if summary_hidden_mode {
-        main_layout = main_layout.constraints(
-            [
-                Constraint::Length(method_len + 3),
-                Constraint::Length(9),
-                Constraint::Min(0),
-            ]
-            .as_ref(),
-        );
+        main_layout = main_layout.constraints([
+            Constraint::Length(method_len + 3),
+            Constraint::Length(9),
+            Constraint::Min(0),
+        ]);
         summary_layout =
             summary_layout.constraints([Constraint::Percentage(50), Constraint::Percentage(50)]);
     } else {
         match mode_selection.index {
             0 => {
-                main_layout = main_layout.constraints(
-                    [
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(method_len + 3),
-                        Constraint::Length(9),
-                        Constraint::Min(0),
-                    ]
-                    .as_ref(),
-                );
+                main_layout = main_layout.constraints([
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(method_len + 3),
+                    Constraint::Length(9),
+                    Constraint::Min(0),
+                ]);
                 summary_layout = summary_layout
                     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)]);
             }
             1 => {
-                main_layout = main_layout.constraints(
-                    [
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(method_len + 3),
-                        Constraint::Length(9),
-                        Constraint::Min(0),
-                    ]
-                    .as_ref(),
-                );
+                main_layout = main_layout.constraints([
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(method_len + 3),
+                    Constraint::Length(9),
+                    Constraint::Min(0),
+                ]);
                 summary_layout = summary_layout
                     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)]);
             }
             2 => {
-                main_layout = main_layout.constraints(
-                    [
-                        Constraint::Length(3),
-                        Constraint::Length(method_len + 3),
-                        Constraint::Length(9),
-                        Constraint::Min(0),
-                    ]
-                    .as_ref(),
-                );
+                main_layout = main_layout.constraints([
+                    Constraint::Length(3),
+                    Constraint::Length(method_len + 3),
+                    Constraint::Length(9),
+                    Constraint::Min(0),
+                ]);
                 summary_layout = summary_layout
                     .constraints([Constraint::Percentage(50), Constraint::Percentage(50)]);
             }

--- a/src/tx_handler/tx_data.rs
+++ b/src/tx_handler/tx_data.rs
@@ -488,13 +488,13 @@ impl TxData {
         let mut user_amount = self.amount.to_lowercase();
 
         if user_amount.contains('k') {
-            user_amount = user_amount.replace("k", "");
+            user_amount = user_amount.replace('k', "");
             let amount: f64 = user_amount.parse().unwrap();
             self.amount = (amount * 1_000.0).to_string();
         }
 
         if user_amount.contains('m') {
-            user_amount = user_amount.replace("m", "");
+            user_amount = user_amount.replace('m', "");
             let amount: f64 = user_amount.parse().unwrap();
             self.amount = (amount * 1_000_000.0).to_string();
         }


### PR DESCRIPTION
Resolves #75 

- The Home page now has two more rows on the balance section highlighting daily expense and income
- Home page animation code repetition has been reduced 